### PR TITLE
feat: abort previous requests on new changes

### DIFF
--- a/src/util/fetch-image.ts
+++ b/src/util/fetch-image.ts
@@ -1,6 +1,10 @@
 import { blobToBase64 } from "@/lib/utils";
 
-export const fetchImage = async (input_image: string, prompt: string) => {
+export const fetchImage = async (
+  input_image: string,
+  prompt: string,
+  signal?: AbortSignal,
+) => {
   const response = await fetch("/api/run", {
     headers: {
       accept: "image/jpeg",
@@ -18,6 +22,7 @@ export const fetchImage = async (input_image: string, prompt: string) => {
       height: 768,
     }),
     method: "POST",
+    signal,
   });
   if (response.status !== 200) throw new Error("Failed to fetch image");
   const blob = await response.blob();


### PR DESCRIPTION
This will abort the previous request before new request are sent.
Because it's a waste of resource to generate images based on outdated states while real-time changes are made.

Further improvements: the server needs to stop generation when client aborts an in-flight request.